### PR TITLE
Add auto retry

### DIFF
--- a/src/main/java/com/liveramp/captain/daemon/BaseCaptainBuilder.java
+++ b/src/main/java/com/liveramp/captain/daemon/BaseCaptainBuilder.java
@@ -11,6 +11,8 @@ import com.liveramp.captain.notifier.CaptainDaemonInternalNotifier;
 import com.liveramp.captain.notifier.CaptainNotifier;
 import com.liveramp.captain.notifier.DefaultCaptainLoggingNotifier;
 import com.liveramp.captain.request_lock.CaptainRequestLock;
+import com.liveramp.captain.retry.DefaultFailedRequestPolicy;
+import com.liveramp.captain.retry.FailedRequestPolicy;
 import com.liveramp.daemon_lib.Daemon;
 import com.liveramp.daemon_lib.DaemonLock;
 import com.liveramp.daemon_lib.JobletCallback;
@@ -52,12 +54,18 @@ public class BaseCaptainBuilder<T extends BaseCaptainBuilder<T>> {
   private Optional<JobletCallback<CaptainRequestConfig>> onNewConfigCallback = Optional.empty();
   private Optional<JobletCallback<CaptainRequestConfig>> successCallback = Optional.empty();
   private Optional<JobletCallback<CaptainRequestConfig>> failureCallback = Optional.empty();
+  private FailedRequestPolicy failedRequestPolicy = new DefaultFailedRequestPolicy();
 
   protected BaseCaptainBuilder(String identifier, CaptainConfigProducer configProducer, ManifestManager manifestManager, RequestUpdater requestUpdater) {
     this.identifier = identifier;
     this.configProducer = configProducer;
     this.manifestManager = manifestManager;
     this.requestUpdater = requestUpdater;
+  }
+
+  public T setFailedRequestPolicy(FailedRequestPolicy failedRequestPolicy) {
+    this.failedRequestPolicy = failedRequestPolicy;
+    return self;
   }
 
   /**
@@ -185,7 +193,8 @@ public class BaseCaptainBuilder<T extends BaseCaptainBuilder<T>> {
         manifestManager,
         resolvedCaptainNotifier,
         supportsPending,
-        rammingSpeed
+        rammingSpeed,
+        failedRequestPolicy
     );
 
     ThreadingDaemonBuilder<CaptainRequestConfig> daemonBuilder = new ThreadingDaemonBuilder<>(

--- a/src/main/java/com/liveramp/captain/daemon/ThreadedCaptainJobletFactoryImpl.java
+++ b/src/main/java/com/liveramp/captain/daemon/ThreadedCaptainJobletFactoryImpl.java
@@ -2,6 +2,7 @@ package com.liveramp.captain.daemon;
 
 import com.liveramp.captain.manifest_manager.ManifestManager;
 import com.liveramp.captain.notifier.CaptainNotifier;
+import com.liveramp.captain.retry.FailedRequestPolicy;
 import com.liveramp.daemon_lib.Joblet;
 import com.liveramp.daemon_lib.utils.DaemonException;
 
@@ -11,18 +12,21 @@ public class ThreadedCaptainJobletFactoryImpl implements CaptainJobletFactory {
   private CaptainNotifier notifier;
   private boolean supportsPending;
   private boolean rammingSpeed;
+  private FailedRequestPolicy failedRequestPolicy;
 
   ThreadedCaptainJobletFactoryImpl(
       RequestUpdater requestUpdater,
       ManifestManager manifestManager,
       CaptainNotifier notifier,
       boolean supportsPending,
-      boolean rammingSpeed) {
+      boolean rammingSpeed,
+      FailedRequestPolicy failedRequestPolicy) {
     this.requestUpdater = requestUpdater;
     this.manifestManager = manifestManager;
     this.notifier = notifier;
     this.supportsPending = supportsPending;
     this.rammingSpeed = rammingSpeed;
+    this.failedRequestPolicy = failedRequestPolicy;
   }
 
   @Override
@@ -33,6 +37,7 @@ public class ThreadedCaptainJobletFactoryImpl implements CaptainJobletFactory {
         requestUpdater,
         manifestManager,
         supportsPending,
-        rammingSpeed);
+        rammingSpeed,
+        failedRequestPolicy);
   }
 }

--- a/src/main/java/com/liveramp/captain/retry/DefaultFailedRequestPolicy.java
+++ b/src/main/java/com/liveramp/captain/retry/DefaultFailedRequestPolicy.java
@@ -1,0 +1,11 @@
+package com.liveramp.captain.retry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultFailedRequestPolicy implements FailedRequestPolicy {
+ @Override
+  public FailedRequestAction getFailedRequestAction(Long jobId) {
+        return FailedRequestAction.NO_OP;
+      }
+}

--- a/src/main/java/com/liveramp/captain/retry/FailedRequestPolicy.java
+++ b/src/main/java/com/liveramp/captain/retry/FailedRequestPolicy.java
@@ -1,0 +1,37 @@
+package com.liveramp.captain.retry;
+
+import com.liveramp.captain.daemon.RequestUpdater;
+
+/***
+ * Implementations of this interface are meant to make a decision on what to do when captain picks up a
+ * request in status FAILED. There are three possible return values:
+ *
+ * RETRY: Captain will call the retry method in {@link RequestUpdater}
+ * QUARANTINE: Captain will call the quarantine method in {@link RequestUpdater}
+ * NO_OP: Captain will do nothing. By default captain uses a FailedRequestPolicy that always returns NO_OP.
+ */
+public interface FailedRequestPolicy {
+
+  /***
+   * Method called by captain to know what to do with a failed request
+   * @param jobId id of the failed request
+   * @return action to be executed by captain
+   */
+  FailedRequestAction getFailedRequestAction(Long jobId);
+
+  enum FailedRequestAction {
+    RETRY(1),
+    QUARANTINE(2),
+    NO_OP(3);
+
+    private final int value;
+
+    FailedRequestAction(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
+}


### PR DESCRIPTION
- I don't think we can have some predefined retry implementations give that we have no control over the data model that people are using.
- The config producer has to pick up failed requests in order to be retried