### PR TITLE
use new request context interface

### DIFF
--- a/src/main/java/com/liveramp/captain/request_context/EmptyRequestContext.java
+++ b/src/main/java/com/liveramp/captain/request_context/EmptyRequestContext.java
@@ -9,12 +9,40 @@ public class EmptyRequestContext implements RequestContext {
   }
 
   @Override
+  public void setPriority(int priority) {
+    throw new RuntimeException("Cannot set priority on an EmptyRequestContext");
+  }
+
+  @Override public boolean hasPriority() {
+    return false;
+  }
+
+  @Override
   public ExternalId getExternalId() {
     return null;
   }
 
   @Override
+  public void setExternalId(ExternalId externalId) {
+    throw new RuntimeException("Cannot set ExternalId on an EmptyRequestContext");
+  }
+
+  @Override public boolean hasExternalId() {
+    return false;
+  }
+
+  @Override
   public Map<String, String> getOptions() {
     return null;
+  }
+
+  @Override
+  public boolean hasOptions() {
+    return false;
+  }
+
+  @Override
+  public void setOptions(Map<String, String> options) {
+    throw new RuntimeException("Cannot set options on an EmptyRequestContext");
   }
 }

--- a/src/main/java/com/liveramp/captain/request_context/RequestContext.java
+++ b/src/main/java/com/liveramp/captain/request_context/RequestContext.java
@@ -5,7 +5,19 @@ import java.util.Map;
 public interface RequestContext {
   int getPriority();
 
+  boolean hasPriority();
+
+  void setPriority(int priority);
+
   ExternalId getExternalId();
 
+  boolean hasExternalId();
+
+  void setExternalId(ExternalId externalId);
+
   Map<String, String> getOptions();
+
+  boolean hasOptions();
+
+  void setOptions(Map<String, String> options);
 }


### PR DESCRIPTION
Add methods to the `RequestContext` interface be able to set request context fields and check if they are set.