### PR TITLE
use correct log type in notifiers

### DIFF
--- a/src/main/java/com/liveramp/captain/notifier/CaptainDaemonInternalNotifier.java
+++ b/src/main/java/com/liveramp/captain/notifier/CaptainDaemonInternalNotifier.java
@@ -15,9 +15,10 @@ public class CaptainDaemonInternalNotifier implements DaemonNotifier {
 
   @Override
   public void notify(
-      String subject, Optional<String> body, Optional<? extends Throwable> t) {
+      String subject, Optional<String> body, Optional<? extends Throwable> t
+  ) {
     if (t.isPresent()) {
-      notifier.notify(subject, body.orElse(""), t.get(), CaptainNotifier.NotificationLevel.INFO);
+      notifier.notify(subject, body.orElse(""), t.get(), CaptainNotifier.NotificationLevel.ERROR);
     } else {
       notifier.notify(subject, body.orElse(""), CaptainNotifier.NotificationLevel.INFO);
     }

--- a/src/main/java/com/liveramp/captain/notifier/DefaultCaptainLoggingNotifier.java
+++ b/src/main/java/com/liveramp/captain/notifier/DefaultCaptainLoggingNotifier.java
@@ -20,7 +20,7 @@ public class DefaultCaptainLoggingNotifier implements CaptainNotifier {
         LOG.error(msg);
         break;
       default:
-        throw new RuntimeException("Unknown notification leve: " + notificationLevel);
+        throw new RuntimeException("Unknown notification level: " + notificationLevel);
     }
   }
 

--- a/src/main/java/com/liveramp/captain/notifier/DefaultCaptainLoggingNotifier.java
+++ b/src/main/java/com/liveramp/captain/notifier/DefaultCaptainLoggingNotifier.java
@@ -12,10 +12,15 @@ public class DefaultCaptainLoggingNotifier implements CaptainNotifier {
     switch (notificationLevel) {
       case DEBUG:
         LOG.debug(msg);
+        break;
       case INFO:
         LOG.info(msg);
+        break;
       case ERROR:
         LOG.error(msg);
+        break;
+      default:
+        throw new RuntimeException("Unknown notification leve: " + notificationLevel);
     }
   }
 

--- a/src/main/java/com/liveramp/captain/notifier/DefaultCaptainLoggingNotifier.java
+++ b/src/main/java/com/liveramp/captain/notifier/DefaultCaptainLoggingNotifier.java
@@ -7,9 +7,16 @@ import org.slf4j.LoggerFactory;
 public class DefaultCaptainLoggingNotifier implements CaptainNotifier {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCaptainLoggingNotifier.class);
 
-
   private void notifyInternal(String subject, String body, NotificationLevel notificationLevel) {
-    LOG.info(String.format("[%s]: %s %n%n %s)", notificationLevel.toString(), subject, body));
+    String msg = String.format("[%s]: %s %n%n %s)", notificationLevel.toString(), subject, body);
+    switch (notificationLevel) {
+      case DEBUG:
+        LOG.debug(msg);
+      case INFO:
+        LOG.info(msg);
+      case ERROR:
+        LOG.error(msg);
+    }
   }
 
   @Override


### PR DESCRIPTION
Change the type of log to be used based on the `NotificationLevel`. This is so that exceptions are not logged as `INFO`