### PR TITLE
Add generics to NoOpHandlePersistor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-build
-**/*.iml
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <parent>
     <groupId>com.liveramp</groupId>
     <artifactId>pom-common</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.liveramp</groupId>
       <artifactId>daemon_lib</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/liveramp/captain/handle_persistor/NoOpHandlePersistor.java
+++ b/src/main/java/com/liveramp/captain/handle_persistor/NoOpHandlePersistor.java
@@ -2,24 +2,17 @@ package com.liveramp.captain.handle_persistor;
 
 public class NoOpHandlePersistor<ServiceHandle> implements HandlePersistor<ServiceHandle> {
 
-  private NoOpHandlePersistor() {
-
-  }
-
   @Override
   public void persist(Long id, ServiceHandle o) {
-
+    // no-op
   }
 
-  public static HandlePersistorFactory get() {
-    return new NoOpHandlePersistor.Factory();
-  }
-
-  private static class Factory implements HandlePersistorFactory {
-
-    @Override
-    public HandlePersistor create() {
-      return new NoOpHandlePersistor();
-    }
+  /**
+   * This method predates the use of method references and functional
+   * interfaces.  Modern callers can use {@code NoOpHandlePersistor::new}
+   * instead.
+   */
+  public static <ServiceHandle> HandlePersistorFactory<ServiceHandle> get() {
+    return NoOpHandlePersistor::new;
   }
 }


### PR DESCRIPTION
Adding generics to the return type allows callers to avoid unchecked
assignments.
