### PR TITLE
Catch and notify on all Throwables in Joblet

### DIFF
--- a/src/main/java/com/liveramp/captain/daemon/CaptainJoblet.java
+++ b/src/main/java/com/liveramp/captain/daemon/CaptainJoblet.java
@@ -102,14 +102,14 @@ public class CaptainJoblet implements Joblet {
         default:
           throw new DaemonException("Provided config has a job status that shouldn't be handled by the captain " + config);
       }
-    } catch (Exception e) {
+    } catch (Throwable t) {
       notifier.notify(
           String.format("%s: error in CaptainJoblet", CaptainAlertHelpers.getHostName()),
-          e,
+          t,
           CaptainNotifier.NotificationLevel.ERROR);
-      LOG.error(e.getLocalizedMessage());
+      LOG.error(t.getLocalizedMessage());
       requestUpdater.fail(config.getId());
-      throw e;
+      throw t;
     } finally {
       MDC.remove("id");
     }


### PR DESCRIPTION
The Captain Daemon is a [Threaded Daemon](https://github.com/LiveRamp/captain/blob/0023df5ba5d2a432c8ceec722b8486d3d5909e65/src/main/java/com/liveramp/captain/daemon/BaseCaptainBuilder.java#L267), which means that joblets are executed in separate threads. If a joblet throws a `Throwable`, it is currently possible that nothing catches it, making the thread die silently. This can make debugging extremely difficult, as there is no way to know that a joblet failed, let alone the reason why.

This PR makes sure that the `CaptainJoblet` reacts to a `Throwable`  the way it previously reacted `Exception`s only:
- notify
- log
- update request status
- rethrow

Doing work after catching a `Throwable`  is something to be cautious about, but since `CaptainJoblet` is already doing it [here](https://github.com/LiveRamp/captain/blob/master/src/main/java/com/liveramp/captain/daemon/CaptainJoblet.java#L196-L201) this change is at least not making things worse.

Alternatives considered: 
- Updating `daemon_lib`'s [JobletExecutors.Threaded.get()](https://github.com/LiveRamp/daemon_lib/blob/ef32884950468d286318614499b090366e25bc49/src/main/java/com/liveramp/daemon_lib/executors/JobletExecutors.java#L89) to set an [UncaughtExceptionHandler](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.UncaughtExceptionHandler.html) that would always log/notify on errors
- Updating `daemon_lib`'s [Threaded Joblet Executor](https://github.com/LiveRamp/daemon_lib/blob/master/src/main/java/com/liveramp/daemon_lib/executors/ThreadedJobletExecutor.java#L42) to catch `Throwable` instead of `Exception`

I went with this approach because it had the smallest blast radius and was a really small change, but disagreeing opinions are welcome.

Open question:
Do we want to update the request status when a `Throwable` is thrown? [This](https://github.com/LiveRamp/captain/blob/master/src/main/java/com/liveramp/captain/daemon/CaptainJoblet.java#L196-L201) seems to believe that yes, but it's not obvious to me. If I get an `OutOfMemoryError` or a `NoSuchMethodDefined`, I would probably prefer my requests to stay in the same state and rely on a next run to be successfully treated.